### PR TITLE
Regex filter on graphite timer stats

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -39,6 +39,8 @@ var timerNamespace   = [];
 var gaugesNamespace  = [];
 var setsNamespace     = [];
 
+var timerRegEx;
+
 var graphiteStats = {};
 
 var post_stats = function graphite_post_stats(statString) {
@@ -114,6 +116,9 @@ var flush_stats = function graphite_flush(ts, metrics) {
       var namespace = timerNamespace.concat(key);
       var the_key = namespace.join(".");
       for (timer_data_key in timer_data[key]) {
+	    if (!timerRegEx.test(timer_data_key)) {
+	      continue;
+		}
         var namespace = timerNamespace.concat(key);
         var the_key = namespace.join(".");
 
@@ -183,6 +188,7 @@ exports.init = function graphite_init(startup_time, config, events) {
   prefixGauge     = config.graphite.prefixGauge;
   prefixSet       = config.graphite.prefixSet;
   legacyNamespace = config.graphite.legacyNamespace;
+  timerRegEx      = config.graphite.timerRegEx;
 
   // set defaults for prefixes
   globalPrefix  = globalPrefix !== undefined ? globalPrefix : "stats";
@@ -192,6 +198,9 @@ exports.init = function graphite_init(startup_time, config, events) {
   prefixSet     = prefixSet !== undefined ? prefixSet : "sets";
   legacyNamespace = legacyNamespace !== undefined ? legacyNamespace : true;
 
+  // initialize regex
+  timerRegEx     = timerRegEx !== undefined ? timerRegEx : ".*";
+  timerRegEx     = new RegExp(timerRegEx);
 
   if (legacyNamespace === false) {
     if (globalPrefix !== "") {

--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -116,10 +116,8 @@ var flush_stats = function graphite_flush(ts, metrics) {
     var the_key = namespace.join(".");
     for (timer_data_key in timer_data[key]) {
       if (!timerRegEx.test(timer_data_key)) {
-	    continue;
-	  }
-      var namespace = timerNamespace.concat(key);
-      var the_key = namespace.join(".");
+        continue;
+      }
       if (typeof(timer_data[key][timer_data_key]) === 'number') {
         statString += the_key + '.' + timer_data_key + ' ' + timer_data[key][timer_data_key] + ts_suffix;
       } else {

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -54,7 +54,7 @@ Optional Variables:
     prefixTimer:      graphite prefix for timer metrics [default: "timers"]
     prefixGauge:      graphite prefix for gauge metrics [default: "gauges"]
     prefixSet:        graphite prefix for set metrics [default: "sets"]
-	timerRegEx:       will only send metrics that match key [default: ".*"]
+    timerRegEx:       will only send metrics that match key [default: ".*"]
 
   repeater:         an array of hashes of the for host: and port:
                     that details other statsd servers to which the received

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -54,6 +54,7 @@ Optional Variables:
     prefixTimer:      graphite prefix for timer metrics [default: "timers"]
     prefixGauge:      graphite prefix for gauge metrics [default: "gauges"]
     prefixSet:        graphite prefix for set metrics [default: "sets"]
+	timerRegEx:       will only send metrics that match key [default: ".*"]
 
   repeater:         an array of hashes of the for host: and port:
                     that details other statsd servers to which the received


### PR DESCRIPTION
Simple (perhaps too simple) hack to cut down number of stats that we weren’t using. 
