### PR TITLE
Make it possible to configure which timer metrics not to calculate

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -94,6 +94,17 @@ Optional Variables:
                      [ { metric: 'foo', bins: [] },
                        { metric: '', bins: [ 50, 100, 150, 200, 'inf'] } ]
 
+  ignoreTimerMetrics: for timers, an array of mappings of strings (to match metrics) and
+                      which metric not to calculate. 
+                      default: []
+                      Possible values are: threshold (all thresholds), threshold_sum, threshold_mean, threshold_upper, 
+                        std, upper, lower, count, count_ps, sum, mean, median
+                      First match wins.  examples:
+                      * ignore "sum" and "std" for all metrics except foo
+                      [ { metric: 'foo', names: [] },
+                       { metric: '', names: [ "sum", "std" ] } ]
+                      
+
 */
 {
   graphitePort: 2003

--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -11,6 +11,7 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
     var timer_counters = metrics.timer_counters;
     var pctThreshold = metrics.pctThreshold;
     var histogram = metrics.histogram;
+    var ignoreTimerMetrics = metrics.ignoreTimerMetrics;
 
     for (key in counters) {
       var value = counters[key];
@@ -28,7 +29,16 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         var count = values.length;
         var min = values[0];
         var max = values[count - 1];
-
+        
+        conf = ignoreTimerMetrics || [];
+        noTimerConf = [];
+        for (var i = 0; i < conf.length; i++) {
+          if (key.indexOf(conf[i].metric) > -1) {
+            noTimerConf = conf[i].names;
+            break;
+          }
+        }
+        
         var cumulativeValues = [min];
         for (var i = 1; i < count; i++) {
             cumulativeValues.push(values[i] + cumulativeValues[i-1]);
@@ -39,32 +49,39 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         var thresholdBoundary = max;
 
         var key2;
-
-        for (key2 in pctThreshold) {
-          var pct = pctThreshold[key2];
-          if (count > 1) {
-            var numInThreshold = Math.round(Math.abs(pct) / 100 * count);
-            if (numInThreshold === 0) {
-              continue;
+        
+        if (noTimerConf.indexOf('threshold') == -1) {
+          for (key2 in pctThreshold) {
+            var pct = pctThreshold[key2];
+            if (count > 1) {
+              var numInThreshold = Math.round(Math.abs(pct) / 100 * count);
+              if (numInThreshold === 0) {
+                continue;
+              }
+  
+              if (pct > 0) {
+                thresholdBoundary = values[numInThreshold - 1];
+                sum = cumulativeValues[numInThreshold - 1];
+              } else {
+                thresholdBoundary = values[count - numInThreshold];
+                sum = cumulativeValues[count - 1] - cumulativeValues[count - numInThreshold - 1];
+              }
+              mean = sum / numInThreshold;
             }
-
-            if (pct > 0) {
-              thresholdBoundary = values[numInThreshold - 1];
-              sum = cumulativeValues[numInThreshold - 1];
-            } else {
-              thresholdBoundary = values[count - numInThreshold];
-              sum = cumulativeValues[count - 1] - cumulativeValues[count - numInThreshold - 1];
+  
+            var clean_pct = '' + pct;
+            clean_pct = clean_pct.replace('.', '_').replace('-', 'top');
+            if (noTimerConf.indexOf('threshold_mean') == -1) {
+              current_timer_data["mean_" + clean_pct] = mean;
             }
-            mean = sum / numInThreshold;
+            if (noTimerConf.indexOf('threshold_upper') == -1) {
+              current_timer_data[(pct > 0 ? "upper_" : "lower_") + clean_pct] = thresholdBoundary;
+            }
+            if (noTimerConf.indexOf('threshold_sum') == -1) {
+              current_timer_data["sum_" + clean_pct] = sum;
+            }
           }
-
-          var clean_pct = '' + pct;
-          clean_pct = clean_pct.replace('.', '_').replace('-', 'top');
-          current_timer_data["mean_" + clean_pct] = mean;
-          current_timer_data[(pct > 0 ? "upper_" : "lower_") + clean_pct] = thresholdBoundary;
-          current_timer_data["sum_" + clean_pct] = sum;
-
-        }
+      }
 
         sum = cumulativeValues[count-1];
         mean = sum / count;
@@ -78,14 +95,30 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         var median = (count % 2) ? values[mid] : (values[mid-1] + values[mid])/2;
 
         var stddev = Math.sqrt(sumOfDiffs / count);
-        current_timer_data["std"] = stddev;
-        current_timer_data["upper"] = max;
-        current_timer_data["lower"] = min;
-        current_timer_data["count"] = timer_counters[key];
-        current_timer_data["count_ps"] = timer_counters[key] / (flushInterval / 1000);
-        current_timer_data["sum"] = sum;
-        current_timer_data["mean"] = mean;
-        current_timer_data["median"] = median;
+        if (noTimerConf.indexOf('std') == -1) {
+          current_timer_data["std"] = stddev;
+        }
+        if (noTimerConf.indexOf('upper') == -1) {
+          current_timer_data["upper"] = max;
+        }
+        if (noTimerConf.indexOf('lower') == -1) {
+          current_timer_data["lower"] = min;
+        }
+        if (noTimerConf.indexOf('count') == -1) {
+          current_timer_data["count"] = timer_counters[key];
+        }
+        if (noTimerConf.indexOf('count_ps') == -1) {
+          current_timer_data["count_ps"] = timer_counters[key] / (flushInterval / 1000);
+        }
+        if (noTimerConf.indexOf('sum') == -1) {
+          current_timer_data["sum"] = sum;
+        }
+        if (noTimerConf.indexOf('mean') == -1) {
+          current_timer_data["mean"] = mean;
+        }
+        if (noTimerConf.indexOf('median') == -1) {
+          current_timer_data["median"] = median;
+        }
 
         // note: values bigger than the upper limit of the last bin are ignored, by design
         conf = histogram || [];

--- a/stats.js
+++ b/stats.js
@@ -61,7 +61,8 @@ function flushMetrics() {
     counter_rates: counter_rates,
     timer_data: timer_data,
     pctThreshold: pctThreshold,
-    histogram: conf.histogram
+    histogram: conf.histogram,
+    ignoreTimerMetrics: conf.ignoreTimerMetrics
   };
 
   // After all listeners, reset the stats

--- a/test/process_metrics_tests.js
+++ b/test/process_metrics_tests.js
@@ -11,6 +11,7 @@ module.exports = {
     var timer_counters = {};
     var sets = {};
     var pctThreshold = null;
+    var noTimerMetrics = null;
 
     this.metrics = {
       counters: counters,
@@ -18,7 +19,8 @@ module.exports = {
       timers: timers,
       timer_counters: timer_counters,
       sets: sets,
-      pctThreshold: pctThreshold
+      pctThreshold: pctThreshold,
+      noTimerMetrics: noTimerMetrics
     }
     callback();
   },


### PR DESCRIPTION
This uses a configuration like the histograms. Its possible to specify to ignore specific timer data for specific metrics. See exampleConfig.js
I could not come up with a good name for this option, any suggestions ?
