### PR TITLE
Handle stream errors in TCP server.

### DIFF
--- a/servers/tcp.js
+++ b/servers/tcp.js
@@ -22,6 +22,10 @@ exports.start = function(config, callback) {
              callback(packet, new rinfo(stream, packet));
           }
       });
+
+      stream.on('error', function(error) {
+        console.error(error);
+      });
   });
 
   server.on('listening', function() {


### PR DESCRIPTION
Receiving connection errors caused TCP server to crash:

```
events.js:154
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at exports._errnoException (util.js:890:11)
    at TCP.onread (net.js:550:26)
```

It can be reproduced by Python script:

```
import socket
import struct

s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
s.connect(('127.0.0.1', 8125))
l_onoff= 1
l_linger = 0
s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii',
l_onoff, l_linger))
s.close()
```
