### PR TITLE
Max ttl for gauges

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+statsd (0.8.5-2) unstable; urgency=low
+
+  * Move away idleStats related configuration variables from the flushMetrics method
+  * Write new tests for the gaugesMaxTTL option
+  * Write the logic for handling the deletion in the presence of gaugesMaxTTL
+
+ -- Claudio Benfatto <claudio.benfatto@gmail.com>  Thu, 17 Feb 2020 00:00:00 +0000
+
 statsd (0.8.5-1) unstable; urgency=low
 
   * Update lodash (sub dependency) for security fix

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -62,7 +62,7 @@ Optional Variables:
                     as opposed to sending 0.  For gauges, this unsets the gauge (instead of sending
                     the previous value). Can be individually overriden. [default: false]
   deleteGauges:     don't send values to graphite for inactive gauges, as opposed to sending the previous value [default: false]
-  gaugesMaxTTL:  number of flush cycles to wait before the gauge is marked as inactive, to use in combination with deleteGauges [default: 1]
+  gaugesMaxTTL:     number of flush cycles to wait before the gauge is marked as inactive, to use in combination with deleteGauges [default: 1]
   deleteTimers:     don't send values to graphite for inactive timers, as opposed to sending 0 [default: false]
   deleteSets:       don't send values to graphite for inactive sets, as opposed to sending 0 [default: false]
   deleteCounters:   don't send values to graphite for inactive counters, as opposed to sending 0 [default: false]

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -62,6 +62,7 @@ Optional Variables:
                     as opposed to sending 0.  For gauges, this unsets the gauge (instead of sending
                     the previous value). Can be individually overriden. [default: false]
   deleteGauges:     don't send values to graphite for inactive gauges, as opposed to sending the previous value [default: false]
+  gaugesMaxTTL:  number of flush cycles to wait before the gauge is marked as inactive, to use in combination with deleteGauges [default: 1]
   deleteTimers:     don't send values to graphite for inactive timers, as opposed to sending 0 [default: false]
   deleteSets:       don't send values to graphite for inactive sets, as opposed to sending 0 [default: false]
   deleteCounters:   don't send values to graphite for inactive counters, as opposed to sending 0 [default: false]

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,6 +11,10 @@ function isNumber(str) {
     return Boolean(str && !isNaN(str));
 }
 
+function isInteger(x) {
+    return (typeof x === 'number') && (x % 1 === 0);
+}
+
 function isValidSampleRate(str) {
     let validSampleRate = false;
     if(str.length > 1 && str[0] === '@') {
@@ -52,6 +56,7 @@ function is_valid_packet(fields) {
 }
 
 exports.is_valid_packet = is_valid_packet;
+exports.isInteger= isInteger;
 
 exports.writeConfig = function(config, stream) {
   stream.write("\n");

--- a/stats.js
+++ b/stats.js
@@ -186,7 +186,7 @@ config.configFile(process.argv[2], function (config) {
   l = new logger.Logger(config.log || {});
 
   // force conf.gaugesMaxTTL to 1 if it not a positive integer > 1
-  if (Number.isInteger(conf.gaugesMaxTTL) && conf.gaugesMaxTTL > 1) {
+  if (helpers.isInteger(conf.gaugesMaxTTL) && conf.gaugesMaxTTL > 1) {
     conf.gaugesMaxTTL = conf.gaugesMaxTTL;
   } else {
     conf.gaugesMaxTTL = 1;


### PR DESCRIPTION
Hello here,

this PR is related to the following issue: https://github.com/etsy/statsd/issues/584

An overview of the changes I've made:

- Move away `idleStats` related configuration variables from the `flushMetrics` method
- Write new tests for the `gaugesMaxTTL` option
- Write the logic for handling the deletion in the presence of `gaugesMaxTTL`

The aim of this PR is to fix the behaviour involved in gauges deletion. 
The typical use case scenario is when gauges deletion is set to true via the `deleteGauges` flag but new values are actually sent with a frequency lower than the `flushInterval`.

In this case, the gauge's default behaviour and assumption of sending the previous value if no new one has been received since is broken by the gauge deletion process.

I've chosen the path of least impact to the existing code, but I'm aware that at least 2 optimisations are possible:

- We actually don't need to populate an additional data structure (`gaugesTTL`) when the `gaugesMaxTTL` param is set to 1, as this would exactly coincide with the previous behaviour
- We could save additional memory if we kept the `gaugesMaxTTL` within the metrics.gauges associative array, but this would require code changes in other parts of the program

Let me know what you think about this PR. I'm glad to make changes if asked/required.
And please consider that nodejs is definitely not my best-known programming language.

Thanks,
Claudio Benfatto 