### PR TITLE
removes -q switch

### DIFF
--- a/utils/check_statsd_health
+++ b/utils/check_statsd_health
@@ -48,7 +48,7 @@ while getopts ":H:P:k" opt; do
     esac
 done
 
-HEALTH="$(echo -e "health\n" | nc -q1 "${HOST}" "${PORT}")"
+HEALTH="$(echo -e "health\n" | nc "${HOST}" "${PORT}")"
 echo "Statsd '${HOST}:${PORT}' responded: '${HEALTH}'"
 
 if [[ "${HEALTH}" == "health: up" ]]; then


### PR DESCRIPTION
This commit removes the -q switch which isn't supported by all netcat
variants. More information in #602.