### PR TITLE
Enhancement: populate default config

### DIFF
--- a/bin/statsd
+++ b/bin/statsd
@@ -1,2 +1,6 @@
 #!/usr/bin/env node
+if (process.argv.slice(2).length == 0) {
+  process.argv.push('config.js');
+}
+
 require('./../stats.js');


### PR DESCRIPTION
This makes `./bin/statsd` work even when the default `config.js` is not
explicitely provided.