### PR TITLE
Suppressing TCP errors from clients to prevent TCP server crashes

### DIFF
--- a/servers/tcp.js
+++ b/servers/tcp.js
@@ -22,6 +22,10 @@ exports.start = function(config, callback) {
              callback(packet, new rinfo(stream, packet));
           }
       });
+
+      stream.on('error', function (err) {
+          // don't kill the server due to connection errors from a client
+      });
   });
 
   server.on('listening', function() {


### PR DESCRIPTION
Currently, when using a TCP server, any TCP errors from a client connection will cause the server to abort. For example, if a client sends a RST packet, the server will bail with this error:
```
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at exports._errnoException (util.js:1036:11)
    at TCP.onread (net.js:564:26)
```

This PR simply adds a no-op error handler on client sockets to prevent the error from bubbling up.