### PR TITLE
add mysql backend link to docs/backend.md

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -47,6 +47,7 @@ queues and third-party services.
 - [librato-backend](https://github.com/librato/statsd-librato-backend)
 - [mongo-backend](https://github.com/dynmeth/mongo-statsd-backend)
 - [monitis backend](https://github.com/jeremiahshirk/statsd-monitis-backend)
+- [mysql backend](https://github.com/fradinni/nodejs-statsd-mysql-backend)
 - [netuitive backend](https://github.com/Netuitive/statsd-netuitive-backend)
 - [opentsdb backend](https://github.com/emurphy/statsd-opentsdb-backend)
 - [socket.io-backend](https://github.com/Chatham/statsd-socket.io)


### PR DESCRIPTION
We have a duplicated list of backends across the main repo docs and the wiki docs, since the one in the main repo be edited via pull requests a bit easier I've added the one it was missing. If this gets merged, I suggest we remove the page from the wiki.

It might make sense to port the entire wiki into the `/docs` dir of the repo after this as well, thoughts?