### PR TITLE
Add myself (elliot blackburn) to maintainers.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,6 +18,7 @@ with statsd and how much time you think you can roughly spend on the project
 
 - **Daniel Schauenberg**: As a maintainer of Statsd, I agree to the [Developer Certificate of Origin][dco].
 - **Mike Heffner**: As a maintainer of Statsd, I agree to the [Developer Certificate of Origin][dco].
+- **Elliot Blackburn**: As a maintainer of Statsd, I agree to the [Developer Certificate of Origin][dco].
 
 [dco]: https://github.com/statsd/statsd/blob/5f58a9cc7442900c2e553ed1df3d6ce99e885226/DCO.txt
 


### PR DESCRIPTION
This is my submission to become an official statsd maintainer.

## About me
I'm a software engineer currently at Just-Eat, I live in the UK and have worked with nodejs for around 4-ish years. I've worked with node 0.10 all the way to node 10.x and have experience with TypeScript as well as standard JS.

## Contributions
I've been using statsd myself for a number of years and my current employer makes liberal use of it. Since the beginning of the attempted "revivial" of statsd I've picked up a number of PR reviews. I've also begun cleaning up the infrastructure and documentation.

## Reasons for applying
Statsd is a very useful project and I'd like to see it continue to succeed and make aggregating metrics easy. I also like the challenge of bringing an older project up to date with current standards and practices.

cc @mrtazz 