### PR TITLE
Allow for filtering on what Timer metrics are sent out by statsd

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.8.0 (05/05/2016)
+- Modularized injest servers, with support for loading multiple servers
+- Added configurable tcp injest server
+- Added unix socket injest support
+- Added tcp repeater functionality
+- Added pickle protocol support to graphite backend
+- Added configurable IPv6 and TCP support to proxy
+- Added telnet admin interface to proxy
+- Multiple variable scoping fixes
+- Fixes to flush timer to reduce bucket drift
+- Fixes to ruby and java example client code
+- Dropped support for node v0.8.x
+- Fixed dependency issues for modern node versions
+- Updated npm hashring dependency to v3.2.0
+- Replaced npm node-syslog dependency with modern-syslog v1.1.2
+
 ## v0.7.2 (09/02/2014)
 - Fixes to detecting valid packets
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,26 @@
+statsd (0.8.0-1) unstable; urgency=low
+
+  * Modularized injest servers, with support for loading multiple servers
+  * Added configurable tcp injest server
+  * Added tcp repeater functionality
+  * Added unix socket injest support
+  * Added pickle protocol support to graphite backend
+  * Added configurable IPv6 and TCP support to proxy
+  * Added telnet admin interface to proxy
+  * Multiple variable scoping fixes
+  * Fixes to flush timer to reduce bucket drift
+  * Fixes to ruby and java example client code
+  * Dropped support for node v0.8.x
+  * Fixed dependency issues for modern node versions
+  * Updated npm hashring dependency to v3.2.0
+  * Replaced npm node-syslog dependency with modern-syslog v1.1.2
+  * Add systemd services for statsd and statsd-proxy
+  * Add servers directory to package
+  * Removed duplicated libs from package
+  * Add npm dependency for postinst
+
+ -- Patrick Koch <pk.hzzrd@gmail.com>  Thu, 5 May 2016 01:00:00 +0000
+
 statsd (0.7.2-1) unstable; urgency=low
 
   * Fixes to detecting valid packets

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -60,7 +60,7 @@ Optional Variables:
     log:            location of log file for frequent keys [default: STDOUT]
   deleteIdleStats:  don't send values to graphite for inactive counters, sets, gauges, or timers
                     as opposed to sending 0.  For gauges, this unsets the gauge (instead of sending
-                    the previous value). Can be individually overriden. [default: false]
+                    the previous value). Can be individually overridden. [default: false]
   deleteGauges:     don't send values to graphite for inactive gauges, as opposed to sending the previous value [default: false]
   deleteTimers:     don't send values to graphite for inactive timers, as opposed to sending 0 [default: false]
   deleteSets:       don't send values to graphite for inactive sets, as opposed to sending 0 [default: false]

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,7 +30,7 @@ var Configurator = function (file) {
   });
 };
 
-util.inherits(Configurator, require('events'));
+util.inherits(Configurator, require('events').EventEmitter);
 
 exports.Configurator = Configurator;
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,28 @@
 {
   "name": "statsd",
-  "description": "A simple, lightweight network daemon to collect metrics over UDP",
-  "author": "Etsy",
+  "version": "0.8.0",
+  "description": "Network daemon for the collection and aggregation of realtime application metrics",
+  "author": {
+      "name": "Etsy",
+      "url": "https://codeascraft.com"
+  },
   "license" : "MIT",
-  "scripts": {
-    "test": "./run_tests.sh",
-    "start": "node stats.js config.js",
-    "install-windows-service": "node_modules\\.bin\\winser -i",
-    "uninstall-windows-service": "node_modules\\.bin\\winser -r"
+  "homepage": "https://github.com/etsy/statsd",
+  "bugs": "https://github.com/etsy/statsd/issues",
+  "keywords": {
+      "statsd",
+      "etsy",
+      "metric",
+      "aggregation",
+      "realtime"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/etsy/statsd.git"
   },
-  "version": "0.7.2",
+  "engines": {
+    "node" : ">=0.10"
+  },
   "dependencies": {
     "generic-pool": "2.2.0"
   },
@@ -27,8 +36,13 @@
     "hashring":"3.2.0",
     "winser": "=0.1.6"
   },
-  "engines": {
-    "node" : ">=0.8"
+  "bin": {
+      "statsd": "./bin/statsd"
   },
-  "bin": { "statsd": "./bin/statsd" }
+  "scripts": {
+    "test": "./run_tests.sh",
+    "start": "node stats.js config.js",
+    "install-windows-service": "node_modules\\.bin\\winser -i",
+    "uninstall-windows-service": "node_modules\\.bin\\winser -r"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "license" : "MIT",
   "homepage": "https://github.com/etsy/statsd",
   "bugs": "https://github.com/etsy/statsd/issues",
-  "keywords": {
+  "keywords": [
       "statsd",
       "etsy",
       "metric",
       "aggregation",
       "realtime"
-  },
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/etsy/statsd.git"


### PR DESCRIPTION
Currently there are over a dozen metrics that get sent out for every timer stat that comes in. Being able to filter on the specific aggregated metrics you want for a timer at the config level will allow for drastic reduction in the data sent out from statsd and stored.

The config that I've added is `calculated_timer_metrics` which by default will send all metrics, however once any other value(s) are added, it will only send those specified. This also allows for the not sending percentile metrics as well.

Currently running these changes in production has reduced our Carbon/whisper load by ~20%.

Related to this issue:
https://github.com/statsd/statsd/issues/235