### PR TITLE
Add skipCounterRates functionality to reduce metric volume

### DIFF
--- a/docs/metric_types.md
+++ b/docs/metric_types.md
@@ -13,6 +13,10 @@ If the count at flush is 0 then you can opt to send no metric at all for
 this counter, by setting `config.deleteCounters` (applies only to graphite
 backend).  Statsd will send both the rate as well as the count at each flush.
 
+The rate can be skipped with the `config.skipCounterRates` option.  This is a
+metric volume saving measure.  The rates will not be calculated in statsd, but
+can be calculated at query time by dividing count by flushInterval.
+
 ### Sampling
 
     gorets:1|c|@0.1

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -65,6 +65,8 @@ Optional Variables:
   deleteTimers:     don't send values to graphite for inactive timers, as opposed to sending 0 [default: false]
   deleteSets:       don't send values to graphite for inactive sets, as opposed to sending 0 [default: false]
   deleteCounters:   don't send values to graphite for inactive counters, as opposed to sending 0 [default: false]
+  skipCounterRates: don't send the rate value for counters. This can help reduce counts of metrics.
+                    Rate can be caclulated at query time by dividing count by the flushInterval [default: false]
   prefixStats:      prefix to use for the statsd statistics data for this running instance of statsd [default: statsd]
                     applies to both legacy and new namespacing
   keyNameSanitize:  sanitize all stat names on ingress [default: true]

--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -1,6 +1,6 @@
 /*jshint node:true, laxcomma:true */
 
-var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
+var process_metrics = function (metrics, flushInterval, skipCounterRates, ts, flushCallback) {
     var starttime = Date.now();
     var key;
     var counter_rates = {};
@@ -12,11 +12,13 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
     var pctThreshold = metrics.pctThreshold;
     var histogram = metrics.histogram;
 
-    for (key in counters) {
-      var value = counters[key];
+    if(skipCounterRates === false) {
+      for (key in counters) {
+        var value = counters[key];
 
-      // calculate "per second" rate
-      counter_rates[key] = value / (flushInterval / 1000);
+        // calculate "per second" rate
+        counter_rates[key] = value / (flushInterval / 1000);
+      }
     }
 
     for (key in timers) {

--- a/stats.js
+++ b/stats.js
@@ -100,6 +100,7 @@ function flushMetrics() {
       conf.deleteSets = conf.deleteSets !== undefined ? conf.deleteSets : true;
       conf.deleteGauges = conf.deleteGauges !== undefined ? conf.deleteGauges : true;
     }
+    conf.skipCounterRates = conf.skipCounterRates !== undefined ? conf.skipCounterRates : false;
 
     // Clear the counters
     conf.deleteCounters = conf.deleteCounters || false;
@@ -148,7 +149,7 @@ function flushMetrics() {
     }
   });
 
-  pm.process_metrics(metrics_hash, flushInterval, time_stamp, function emitFlush(metrics) {
+  pm.process_metrics(metrics_hash, flushInterval, conf.skipCounterRates, time_stamp, function emitFlush(metrics) {
     backendEvents.emit('flush', time_stamp, metrics);
   });
 

--- a/test/process_metrics_tests.js
+++ b/test/process_metrics_tests.js
@@ -25,22 +25,30 @@ module.exports = {
   counters_has_stats_count: function(test) {
     test.expect(1);
     this.metrics.counters['a'] = 2;
-    pm.process_metrics(this.metrics, 1000, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 1000, false, this.time_stamp, function(){});
     test.equal(2, this.metrics.counters['a']);
     test.done();
   },
   counters_has_correct_rate: function(test) {
     test.expect(1);
     this.metrics.counters['a'] = 2;
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     test.equal(20, this.metrics.counter_rates['a']);
+    test.done();
+  },
+  counters_can_skip_rates: function(test) {
+    test.expect(1);
+    this.metrics.counters['a'] = 2;
+    this.metrics.counters['b'] = 200;
+    pm.process_metrics(this.metrics, 100, true, this.time_stamp, function(){});
+    test.equal(0, Object.keys(this.metrics.counter_rates).length);
     test.done();
   },
   timers_handle_empty: function(test) {
     test.expect(1);
     this.metrics.timers['a'] = [];
     this.metrics.timer_counters['a'] = 0;
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     //potentially a cleaner way to check this
     test.equal(undefined, this.metrics.counter_rates['a']);
     test.done();
@@ -49,7 +57,7 @@ module.exports = {
     test.expect(9);
     this.metrics.timers['a'] = [100];
     this.metrics.timer_counters['a'] = 1;
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(0, timer_data.std);
     test.equal(100, timer_data.upper);
@@ -66,7 +74,7 @@ module.exports = {
     test.expect(9);
     this.metrics.timers['a'] = [100, 200, 300];
     this.metrics.timer_counters['a'] = 3;
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(81.64965809277261, timer_data.std);
     test.equal(300, timer_data.upper);
@@ -85,7 +93,7 @@ module.exports = {
     this.metrics.timers['a'] = [100];
     this.metrics.timer_counters['a'] = 1;
     this.metrics.pctThreshold = [90];
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(100, timer_data.mean_90);
     test.equal(100, timer_data.upper_90);
@@ -98,7 +106,7 @@ module.exports = {
     this.metrics.timers['a'] = [100];
     this.metrics.timer_counters['a'] = 1;
     this.metrics.pctThreshold = [90, 80];
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(1, timer_data.count_90);
     test.equal(100, timer_data.mean_90);
@@ -116,7 +124,7 @@ module.exports = {
     this.metrics.timers['a'] = [100, 200, 300];
     this.metrics.timer_counters['a'] = 3;
     this.metrics.pctThreshold = [90];
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(3, timer_data.count_90);
     test.equal(200, timer_data.mean_90);
@@ -131,7 +139,7 @@ module.exports = {
     this.metrics.timers['a'] = [100, 200, 300];
     this.metrics.timer_counters['a'] = 3;
     this.metrics.pctThreshold = [90, 80];
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(3, timer_data.count);
     test.equal(3, timer_data.count_90);
@@ -154,7 +162,7 @@ module.exports = {
     this.metrics.timers['a'] = [100, 200, 300];
     this.metrics.timer_counters['a'] = 50;
     this.metrics.pctThreshold = [90, 80];
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(50, timer_data.count);
     test.equal(500, timer_data.count_ps);
@@ -178,7 +186,7 @@ module.exports = {
                                { metric: 'abcd', bins: [ 1, 5, 'inf'] },
                                { metric: 'abc', bins: [ 1, 2.21, 'inf'] },
                                { metric: 'a', bins: [ 1, 2] } ];
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data;
     // nothing matches the 'abcd' config, so nothing has bin_5
     test.equal(undefined, timer_data['a']['histogram']['bin_5']);
@@ -208,7 +216,7 @@ module.exports = {
     test.expect(3);
     this.metrics.timers['a'] = [100];
     this.metrics.pctThreshold = [-10];
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(100, timer_data.mean_top10);
     test.equal(100, timer_data.lower_top10);
@@ -219,7 +227,7 @@ module.exports = {
     test.expect(3);
     this.metrics.timers['a'] = [10, 10, 10, 10, 10, 10, 10, 10, 100, 200];
     this.metrics.pctThreshold = [-20];
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(150, timer_data.mean_top20);
     test.equal(100, timer_data.lower_top20);
@@ -228,7 +236,7 @@ module.exports = {
   },
     statsd_metrics_exist: function(test) {
     test.expect(1);
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     statsd_metrics = this.metrics.statsd_metrics;
     test.notEqual(undefined, statsd_metrics["processing_time"]);
     test.done();
@@ -236,7 +244,7 @@ module.exports = {
     timers_multiple_times_even: function(test) {
     test.expect(1);
     this.metrics.timers['a'] = [300, 200, 400, 100];
-    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    pm.process_metrics(this.metrics, 100, false, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(250, timer_data.median);
     test.done();


### PR DESCRIPTION
This adds a configuration option for skipping the calculation of counter rates. This can save a lot of metric volume if the user uses a consistent flushInterval and would rather calculate rate at query time.