### PR TITLE
Convert codebase from var -> let / const

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,13 +1,13 @@
 /*jshint node:true, laxcomma:true */
 
-var fs  = require('fs')
-  , util = require('util');
+const fs  = require('fs')
+const util = require('util');
 
-var Configurator = function (file) {
+let Configurator = function (file) {
 
-  var self = this;
-  var config = {};
-  var oldConfig = {};
+  let self = this;
+  let config = {};
+  let oldConfig = {};
 
   this.updateConfig = function () {
     util.log('[' + process.pid + '] reading config file: ' + file);
@@ -35,7 +35,7 @@ util.inherits(Configurator, require('events').EventEmitter);
 exports.Configurator = Configurator;
 
 exports.configFile = function(file, callbackFunc) {
-  var config = new Configurator(file);
+  let config = new Configurator(file);
   config.on('configChanged', function() {
     callbackFunc(config.config, config.oldConfig);
   });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,9 +12,9 @@ function isNumber(str) {
 }
 
 function isValidSampleRate(str) {
-    var validSampleRate = false;
+    let validSampleRate = false;
     if(str.length > 1 && str[0] === '@') {
-        var numberStr = str.substring(1);
+        const numberStr = str.substring(1);
         validSampleRate = isNumber(numberStr) && numberStr[0] != '-';
     }
     return validSampleRate;
@@ -55,7 +55,7 @@ exports.is_valid_packet = is_valid_packet;
 
 exports.writeConfig = function(config, stream) {
   stream.write("\n");
-  for (var prop in config) {
+  for (const prop in config) {
     if (!config.hasOwnProperty(prop)) {
       continue;
     }
@@ -63,8 +63,8 @@ exports.writeConfig = function(config, stream) {
       stream.write(prop + ": " + config[prop] + "\n");
       continue;
     }
-    var subconfig = config[prop];
-    for (var subprop in subconfig) {
+    const subconfig = config[prop];
+    for (const subprop in subconfig) {
       if (!subconfig.hasOwnProperty(subprop)) {
         continue;
       }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,6 @@
 /*jshint node:true, laxcomma:true */
 
-var Logger = function (config) {
+const Logger = function (config) {
   this.config  = config;
   this.backend = this.config.backend || 'stdout';
   this.level   = this.config.level || "LOG_INFO";
@@ -24,7 +24,7 @@ Logger.prototype = {
       }
       this.util.log(type + ": " + msg);
     } else {
-      var level;
+      let level;
       if (!type) {
         level = this.level;
       } else {

--- a/lib/mgmt_console.js
+++ b/lib/mgmt_console.js
@@ -14,7 +14,7 @@
 exports.delete_stats = function(stats_type, cmdline, stream) {
 
   //for each metric requested on the command line
-  for (var index in cmdline) {
+  for (const index in cmdline) {
 
     //get a list of deletable metrics that match the request
     deletable = existing_stats(stats_type, cmdline[index]);
@@ -25,7 +25,7 @@ exports.delete_stats = function(stats_type, cmdline, stream) {
     }
 
     //delete all requested metrics
-    for (var del_idx in deletable) {
+    for (const del_idx in deletable) {
       delete stats_type[deletable[del_idx]];
       stream.write("deleted: " + deletable[del_idx] + "\n");
     }
@@ -53,9 +53,9 @@ function existing_stats(stats_type, bucket){
 
   //special case: match a whole 'folder' (and subfolders) of stats
   if (bucket.slice(-2) == ".*") {
-    var folder = bucket.slice(0,-1);
+    const folder = bucket.slice(0,-1);
 
-    for (var name in stats_type) {
+    for (const name in stats_type) {
       //check if stat is in bucket, ie~ name starts with folder
       if (name.substring(0, folder.length) == folder) {
         matches.push(name);

--- a/lib/mgmt_server.js
+++ b/lib/mgmt_server.js
@@ -1,14 +1,14 @@
 /*jshint node:true, laxcomma:true */
 
-var net = require('net');
+const net = require('net');
 
 exports.start = function(config, on_data_callback, on_error_callback) {
-  var server = net.createServer(function(stream) {
+  const server = net.createServer(function(stream) {
       stream.setEncoding('ascii');
 
       stream.on('data', function(data) {
-        var cmdline = data.trim().split(" ");
-        var cmd = cmdline.shift();
+        const cmdline = data.trim().split(" ");
+        const cmd = cmdline.shift();
 
         on_data_callback(cmd, cmdline, stream);
       });

--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -1,53 +1,53 @@
 /*jshint node:true, laxcomma:true */
 
-var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
-    var starttime = Date.now();
-    var key;
-    var counter_rates = {};
-    var timer_data = {};
-    var statsd_metrics = {};
-    var counters = metrics.counters;
-    var timers = metrics.timers;
-    var timer_counters = metrics.timer_counters;
-    var pctThreshold = metrics.pctThreshold;
-    var histogram = metrics.histogram;
+const process_metrics = function (metrics, flushInterval, ts, flushCallback) {
+    const starttime = Date.now();
+    let key;
+    let counter_rates = {};
+    let timer_data = {};
+    let statsd_metrics = {};
+    const counters = metrics.counters;
+    const timers = metrics.timers;
+    const timer_counters = metrics.timer_counters;
+    const pctThreshold = metrics.pctThreshold;
+    const histogram = metrics.histogram;
 
     for (key in counters) {
-      var value = counters[key];
+      const value = counters[key];
 
       // calculate "per second" rate
       counter_rates[key] = value / (flushInterval / 1000);
     }
 
     for (key in timers) {
-      var current_timer_data = {};
+      const current_timer_data = {};
 
       if (timers[key].length > 0) {
         timer_data[key] = {};
 
-        var values = timers[key].sort(function (a,b) { return a-b; });
-        var count = values.length;
-        var min = values[0];
-        var max = values[count - 1];
+        const values = timers[key].sort(function (a,b) { return a-b; });
+        const count = values.length;
+        const min = values[0];
+        const max = values[count - 1];
 
-        var cumulativeValues = [min];
-        var cumulSumSquaresValues = [min * min];
-        for (var i = 1; i < count; i++) {
+        const cumulativeValues = [min];
+        const cumulSumSquaresValues = [min * min];
+        for (let i = 1; i < count; i++) {
             cumulativeValues.push(values[i] + cumulativeValues[i-1]);
             cumulSumSquaresValues.push((values[i] * values[i]) +
                                        cumulSumSquaresValues[i - 1]);
         }
 
-        var sum = min;
-        var sumSquares = min * min;
-        var mean = min;
-        var thresholdBoundary = max;
+        let sum = min;
+        let sumSquares = min * min;
+        let mean = min;
+        let thresholdBoundary = max;
 
-        var key2;
+        let key2;
 
         for (key2 in pctThreshold) {
-          var pct = pctThreshold[key2];
-          var numInThreshold = count;
+          const pct = pctThreshold[key2];
+          let numInThreshold = count;
 
           if (count > 1) {
             numInThreshold = Math.round(Math.abs(pct) / 100 * count);
@@ -68,7 +68,7 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
             mean = sum / numInThreshold;
           }
 
-          var clean_pct = '' + pct;
+          let clean_pct = '' + pct;
           clean_pct = clean_pct.replace('.', '_').replace('-', 'top');
           current_timer_data["count_" + clean_pct] = numInThreshold;
           current_timer_data["mean_" + clean_pct] = mean;
@@ -82,15 +82,15 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         sumSquares = cumulSumSquaresValues[count-1];
         mean = sum / count;
 
-        var sumOfDiffs = 0;
-        for (var i = 0; i < count; i++) {
+        let sumOfDiffs = 0;
+        for (let i = 0; i < count; i++) {
            sumOfDiffs += (values[i] - mean) * (values[i] - mean);
         }
 
-        var mid = Math.floor(count/2);
-        var median = (count % 2) ? values[mid] : (values[mid-1] + values[mid])/2;
+        const mid = Math.floor(count/2);
+        const median = (count % 2) ? values[mid] : (values[mid-1] + values[mid])/2;
 
-        var stddev = Math.sqrt(sumOfDiffs / count);
+        const stddev = Math.sqrt(sumOfDiffs / count);
         current_timer_data["std"] = stddev;
         current_timer_data["upper"] = max;
         current_timer_data["lower"] = min;
@@ -104,7 +104,7 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         // note: values bigger than the upper limit of the last bin are ignored, by design
         conf = histogram || [];
         bins = [];
-        for (var i = 0; i < conf.length; i++) {
+        for (let i = 0; i < conf.length; i++) {
             if (key.indexOf(conf[i].metric) > -1) {
                 bins = conf[i].bins;
                 break;
@@ -116,9 +116,9 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         // the outer loop iterates bins, the inner loop iterates timer values;
         // within each run of the inner loop we should only consider the timer value range that's within the scope of the current bin
         // so we leverage the fact that the values are already sorted to end up with only full 1 iteration of the entire values range
-        var i = 0;
-        for (var bin_i = 0; bin_i < bins.length; bin_i++) {
-          var freq = 0;
+        let i = 0;
+        for (let bin_i = 0; bin_i < bins.length; bin_i++) {
+          let freq = 0;
           for (; i < count && (bins[bin_i] == 'inf' || values[i] < bins[bin_i]); i++) {
             freq += 1;
           }

--- a/lib/process_mgmt.js
+++ b/lib/process_mgmt.js
@@ -1,6 +1,6 @@
-var util = require('util');
+const util = require('util');
 
-var conf;
+let conf;
 
 exports.init = function(config) {
   conf = config;

--- a/lib/set.js
+++ b/lib/set.js
@@ -21,8 +21,8 @@ Set.prototype = {
     this.store = {};
   },
   values: function() {
-    var values = [];
-    for (var value in this.store) {
+    let values = [];
+    for (const value in this.store) {
       values.push(value);
     }
     return values;

--- a/lib/set.js
+++ b/lib/set.js
@@ -1,6 +1,6 @@
 /*jshint node:true, laxcomma:true */
 
-var Set = function() {
+const Set = function() {
   this.store = {};
 };
 

--- a/run_tests.js
+++ b/run_tests.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 try {
-    var reporter = require('nodeunit').reporters.default;
+    const reporter = require('nodeunit').reporters.default;
 }
 catch(e) {
     console.log("Cannot find nodeunit module.");

--- a/servers/tcp.js
+++ b/servers/tcp.js
@@ -1,5 +1,5 @@
-var net  = require('net');
-var fs = require('fs');
+const net  = require('net');
+const fs = require('fs');
 
 function rinfo(tcpstream, data) {
     this.address = tcpstream.remoteAddress;
@@ -9,15 +9,15 @@ function rinfo(tcpstream, data) {
 }
 
 exports.start = function(config, callback) {
-  var server = net.createServer(function(stream) {
+    const server = net.createServer(function(stream) {
       stream.setEncoding('ascii');
 
-      var buffer = '';
+      let buffer = '';
       stream.on('data', function(data) {
           buffer += data;
-          var offset = buffer.lastIndexOf("\n");
+          const offset = buffer.lastIndexOf("\n");
           if (offset > -1) {
-             var packet = buffer.slice(0, offset + 1);
+             const packet = buffer.slice(0, offset + 1);
              buffer = buffer.slice(offset + 1);
              callback(packet, new rinfo(stream, packet));
           }

--- a/servers/udp.js
+++ b/servers/udp.js
@@ -1,8 +1,8 @@
-var dgram  = require('dgram');
+const dgram  = require('dgram');
 
 exports.start = function(config, callback) {
-  var udp_version = config.address_ipv6 ? 'udp6' : 'udp4';
-  var server = dgram.createSocket(udp_version, callback);
+  const udp_version = config.address_ipv6 ? 'udp6' : 'udp4';
+  const server = dgram.createSocket(udp_version, callback);
 
   server.bind(config.port || 8125, config.address || undefined);
   this.server = server;


### PR DESCRIPTION
To begin bringing the codebase up to date with newer JS standards, this patch makes everything a `const` where possible and turns the rest into `let`'s. Thankfully nothing actually requires the flexible `var` scoping so we've been able to remove it completely.