### PR TITLE
test and declare support for Current and LTS node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-- '6'
 - '8'
 - '10'
 - '11'
+- '12'
 script: node run_tests.js
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ general values should be integers.
 Installation and Configuration
 ------------------------------
 
- * Install node.js
+ * Install Node.js (All [`Current` and `LTS` Node.js versions](https://nodejs.org/en/about/releases/) are supported.)
  * Clone the project
  * Create a config file from `exampleConfig.js` and put it somewhere
- * Start the Daemon:  
+ * Start the Daemon:
    `node stats.js /path/to/config`
 
 Usage


### PR DESCRIPTION
This PR tests statsd on all Current and LTS Node.js versions and declares their support in the readme. While `modern-syslog` isn't supported on any LTS or current versions of node  it isn't a blocker for install so I figured I'd propose this support scheme. It gives people ample time to upgrade and keeps the support burden much lower than trying to support nodejs versions without modern language features.