### PR TITLE
Add s390x support for travis. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,21 @@ node_js:
 - '10'
 - '11'
 - '12'
+matrix:
+  include:
+    - os: linux
+    - os: linux
+      arch: s390x
+      node_js: '8'
+    - os: linux
+      arch: s390x
+      node_js: '10'
+    - os: linux
+      arch: s390x
+      node_js: '11'
+    - os: linux
+      arch: s390x
+      node_js: '12'
 script: node run_tests.js
 notifications:
   email: false


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.