### PR TITLE
Fix some typos in documentation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 ## v0.8.5 (07/23/2019)
 
 - Update lodash (sub dependency) for security fix
-- Add the statsd history to the docs
+- Add the StatsD history to the docs
 - Add third party server interfaces to docs
 - Migrate docs from github wiki, and standardise markdown notation
 - Minor formatting proposals
@@ -39,7 +39,7 @@
 
 ## v0.8.1 (03/13/2019)
 
-- drop statsd instance from proxy ring in instance of healthcheck failures (#665)
+- drop StatsD instance from proxy ring in instance of healthcheck failures (#665)
 - Add myself (elliot blackburn) to maintainers.md (#666)
 - add mysql backend link to docs/backend.md
 - Adding myself to MAINTAINERS.
@@ -60,7 +60,7 @@
 - removes -q switch
 - Fix for failing test on node 0.10
 - fix usage of process.EventEmitter
-- Add plugin Warp10 to statsd
+- Add plugin Warp10 to StatsD
 - Updated graphite link to read the docs
 
 ## v0.8.0 (05/05/2016)
@@ -115,7 +115,7 @@
 - added standard Deviation to timers stats (.std)
 - added last_flush_time and last_flush_length metrics to graphite backend
 - added ipv6 support
-- added Statsd repeater backend
+- added StatsD repeater backend
 - added helper script to decide which timers to sample down
 - added Windows service support
 - added Scala example

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,10 +1,10 @@
-statsd is maintained by the following people.
+StatsD is maintained by the following people.
 
 All maintainers must agree to the [Developer Certificate of Origin][dco].
 
 ## Steps to becoming a maintainer
 1. Open a PR where you add yourself to this file and agree to the DCO. Attach a little bit about your experience
-with statsd and how much time you think you can roughly spend on the project
+with StatsD and how much time you think you can roughly spend on the project
 2. Current maintainers will review
 3. If it gets merged, you're in!
 
@@ -16,9 +16,9 @@ with statsd and how much time you think you can roughly spend on the project
 
 ## Current maintainers
 
-- **Daniel Schauenberg**: As a maintainer of Statsd, I agree to the [Developer Certificate of Origin][dco].
-- **Mike Heffner**: As a maintainer of Statsd, I agree to the [Developer Certificate of Origin][dco].
-- **Elliot Blackburn**: As a maintainer of Statsd, I agree to the [Developer Certificate of Origin][dco].
+- **Daniel Schauenberg**: As a maintainer of StatsD, I agree to the [Developer Certificate of Origin][dco].
+- **Mike Heffner**: As a maintainer of StatsD, I agree to the [Developer Certificate of Origin][dco].
+- **Elliot Blackburn**: As a maintainer of StatsD, I agree to the [Developer Certificate of Origin][dco].
 
 [dco]: https://github.com/statsd/statsd/blob/5f58a9cc7442900c2e553ed1df3d6ce99e885226/DCO.txt
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ background (don't do this on a production machine!).
 Tests can be executed with `./run_tests.sh`.
 
 ## History
-statsd was originally written at ([Etsy][etsy]) and released with a [blog post][blog post]
-about how it works and why we created it.
+StatsD was originally written at [Etsy][etsy] and released with a
+[blog post][blog post] about how it works and why we created it.
 
 ## Inspiration
-StatsD was inspired (heavily) by the project (of the same name) at Flickr.
+StatsD was inspired (heavily) by the project of the same name at Flickr.
 Here's a post where Cal Henderson described it in depth:
-[Counting and timing][counting-timing]
+[Counting and timing][counting-timing].
 Cal re-released the code recently:
 [Perl StatsD][Flicker-StatsD]
 
@@ -93,7 +93,7 @@ Cal re-released the code recently:
 
 [graphite]: http://graphite.readthedocs.org/
 [etsy]: http://www.etsy.com
-[blog post]: http://codeascraft.etsy.com/2011/02/15/measure-anything-measure-everything/
+[blog post]: https://codeascraft.etsy.com/2011/02/15/measure-anything-measure-everything/
 [node]: http://nodejs.org
 [nodemods]: http://nodejs.org/api/modules.html
 [counting-timing]: http://code.flickr.com/blog/2008/10/27/counting-timing/

--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ listens for statistics, like counters and timers, sent over [UDP][udp] or
 ## Key Concepts
 
 * *buckets*
+
   Each stat is in its own "bucket". They are not predefined anywhere. Buckets
 can be named anything that will translate to Graphite (periods make folders,
 etc)
 
 * *values*
+
   Each stat will have a value. How it is interpreted depends on modifiers. In
 general values should be integers.
 
 * *flush*
+
   After the flush interval timeout (defined by `config.flushInterval`,
   default 10 seconds), stats are aggregated and sent to an upstream backend service.
 
@@ -24,7 +27,7 @@ general values should be integers.
 ## Installation and Configuration
 
 ### Docker
-Statsd supports docker in two ways:
+StatsD supports docker in two ways:
 * The official docker image on [docker hub](https://hub.docker.com/r/statsd/statsd)
 * Building the image from the bundled [Dockerfile](./Dockerfile)
 
@@ -54,7 +57,7 @@ StatsD running with the default UDP server on localhost would be:
 * [Server Interface][docs_server_interface]
 * [Backend Interface][docs_backend_interface]
 * [Metric Namespacing][docs_namespacing]
-* [Statsd Cluster Proxy][docs_cluster_proxy]
+* [StatsD Cluster Proxy][docs_cluster_proxy]
 
 ## Debugging
 There are additional config variables available for debugging:
@@ -67,7 +70,7 @@ For more information, check the `exampleConfig.js`.
 
 ## Tests
 A test framework has been added using node-unit and some custom code to start
-and manipulate statsd. Please add tests under test/ for any new features or bug
+and manipulate StatsD. Please add tests under test/ for any new features or bug
 fixes encountered. Testing a live server can be tricky, attempts were made to
 eliminate race conditions but it may be possible to encounter a stuck state. If
 doing dev work, a `killall statsd` will kill any stray test servers in the

--- a/docs/additional_tools.md
+++ b/docs/additional_tools.md
@@ -1,5 +1,5 @@
 # Additional Tools
 
-The following are tools you might find useful when using, contributing, or testing statsd.
+The following are tools you might find useful when using, contributing, or testing StatsD.
 
 * [statsd-tg](http://octo.it/statsd-tg) – StatsD traffic generator; generates dummy traffic for load testing (C).

--- a/docs/admin_interface.md
+++ b/docs/admin_interface.md
@@ -2,17 +2,17 @@
 
 A really simple TCP management interface is available by default on port `8126`
 or overriden in the configuration file. Inspired by the memcache stats approach
-this can be used to monitor a live statsd server.  You can interact with the
+this can be used to monitor a live StatsD server.  You can interact with the
 management server by telnetting to port `8126`, the following commands are
 available based on the running server.
 
 ## Common commands
 
-* health [up|down] - a way to get/set the health status of statsd. Alone will get you the current health status. Passing a second command will set the status to the new value. Accepted values are _up_ and _down_.
+* health [up|down] - a way to get/set the health status of StatsD. Alone will get you the current health status. Passing a second command will set the status to the new value. Accepted values are _up_ and _down_.
 * config - a dump of the current configuration
 * quit - close the connection from the server side
 
-## Statsd specific commands
+## StatsD specific commands
 
 * stats - some stats about the running server
 * counters - a dump of all the current counters
@@ -24,8 +24,8 @@ available based on the running server.
 
 The stats output currently will give you:
 
-* uptime: the number of seconds elapsed since statsd started
-* messages.last_msg_seen: the number of elapsed seconds since statsd received a message
+* uptime: the number of seconds elapsed since StatsD started
+* messages.last_msg_seen: the number of elapsed seconds since StatsD received a message
 * messages.bad_lines_seen: the number of bad lines seen since startup
 
 You can use the del commands to delete an individual metric like this :
@@ -61,11 +61,11 @@ The health output:
 * using health up or health down, you can change the current health status.
 * the healthStatus configuration option allows you to set the default health status at start.
 
-## Statsd Proxy specific commands
+## StatsD Proxy specific commands
 
 * status - the status of the current server
 
 The __status__ output currently will give you:
 
-* uptime: the number of seconds elapsed since statsd proxy started
+* uptime: the number of seconds elapsed since StatsD proxy started
 * nodes: a space separated list of host:port for each active node in the ring

--- a/docs/backend_interface.md
+++ b/docs/backend_interface.md
@@ -42,7 +42,7 @@ the `events` object:
 
   The counter_rates and timer_data are precalculated statistics to simplify
   the creation of backends, the statsd_metrics hash contains metrics generated
-  by statsd itself. Each backend module is passed the same set of
+  by StatsD itself. Each backend module is passed the same set of
   statistics, so a backend module should treat the metrics as immutable
   structures. StatsD will reset timers and counters after each
   listener has handled the event.

--- a/docs/client_implementations.md
+++ b/docs/client_implementations.md
@@ -1,6 +1,6 @@
 # StatsD Clients
 
-A number of clients have been made for pushing metrics into statsd and open sourced by the wider community.
+A number of clients have been made for pushing metrics into StatsD and open sourced by the wider community.
 
 **Node**
 * [lynx](https://github.com/dscape/lynx) — Node.js client used by Mozilla, Nodejitsu, etc.

--- a/docs/cluster_proxy.md
+++ b/docs/cluster_proxy.md
@@ -1,26 +1,26 @@
-# Statsd Cluster Proxy
+# StatsD Cluster Proxy
 
-Statsd Cluster Proxy is a udp proxy that sits infront of multiple statsd instances.
+StatsD Cluster Proxy is a udp proxy that sits infront of multiple StatsD instances.
 
 Create a proxyConfig.js file:
 
   `cp exampleProxyConfig.js proxyConfig.js`
 
 Once you have modified your config file run:
-  
+
   `node proxy.js proxyConfig.js`
 
 
-It uses a consistent hashring to send the unique metric names to the same statsd instances so that
+It uses a consistent hashring to send the unique metric names to the same StatsD instances so that
 the aggregation works properly.
 
-It handles a simple health check that dynamically recalculates the hashring if a statsd instance goes offline.
+It handles a simple health check that dynamically recalculates the hashring if a StatsD instance goes offline.
 
 Config Options are documented in the [exampleProxyConfig.js][exampleProxyConfig.js]
 
 ## Notes
 
-In your statsd configuration make sure to have the following configuration set: `deleteIdleStats: true`
+In your StatsD configuration make sure to have the following configuration set: `deleteIdleStats: true`
 
 We plan to remove this restriction in the near future: [#pull/348][pull_348]
 

--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -1,22 +1,22 @@
 # Configuring Graphite for StatsD
 
 Many users have been confused to see their hit counts averaged, gone missing when
-the data is intermittent, or never stored when statsd is sending at a different
+the data is intermittent, or never stored when StatsD is sending at a different
 interval than graphite expects. Careful setup of Graphite as suggested below should help to alleviate all these issues. When configuring Graphite, two main factors you need to consider are:
 
-1. What is the highest resolution of data points kept by Graphite, and at which points in time is data downsampled to lower resolutions. This decision is by nature directly related to your functional requirements: how far back should you keep data? what is the data resolution you actually need? However, the retention rules you set must also be in sync with statsd.
+1. What is the highest resolution of data points kept by Graphite, and at which points in time is data downsampled to lower resolutions. This decision is by nature directly related to your functional requirements: how far back should you keep data? what is the data resolution you actually need? However, the retention rules you set must also be in sync with StatsD.
 
-2. How should data be aggregated when downsampled, in order to correctly preserve its meaning? Graphite of course knows nothing of the 'meaning' of your data, so let's explore the correct setup for the various metrics sent by statsd.
+2. How should data be aggregated when downsampled, in order to correctly preserve its meaning? Graphite of course knows nothing of the 'meaning' of your data, so let's explore the correct setup for the various metrics sent by StatsD.
 
 ### Storage Schemas
 
-To define retention and downsampling which match your needs, edit Graphite's conf/storage-schemas.conf file. Here is a simple example file that would handle all metrics sent by statsd:
+To define retention and downsampling which match your needs, edit Graphite's conf/storage-schemas.conf file. Here is a simple example file that would handle all metrics sent by StatsD:
 
     [stats]
     pattern = ^stats.*
     retentions = 10s:6h,1min:6d,10min:1800d
 
-This translates to: for all metrics starting with 'stats' (i.e. all metrics sent by statsd), capture:
+This translates to: for all metrics starting with 'stats' (i.e. all metrics sent by StatsD), capture:
 
 * 6 hours of 10 second data (what we consider "near-realtime")
 * 6 days of 1 minute data
@@ -27,9 +27,9 @@ These settings have been a good tradeoff so far between size-of-file (database f
 Retentions are read from the file in order and the first pattern that matches is used. 
 Graphite stores each metric in its own database file, and the retentions take effect when a metric file is first created. This means that changing this config file would not affect any files already created. To view or alter the settings on existing files, use whisper-info.py and whisper-resize.py included with the Whisper package.
 
-#### Correlation with statsd's flush interval:
+#### Correlation with StatsD's flush interval:
 
-In the case of the above example, what would happen if you flush from statsd any faster than every 10 seconds? in that case, multiple values for the same metric may reach Graphite at any given 10-second timespan, and only the last value would take hold and be persisted - so your data would immediately be partially lost. 
+In the case of the above example, what would happen if you flush from StatsD any faster than every 10 seconds? in that case, multiple values for the same metric may reach Graphite at any given 10-second timespan, and only the last value would take hold and be persisted - so your data would immediately be partially lost. 
 
 To fix that, simply ensure your flush interval is at least as long as the highest-resolution retention. However, a long interval may cause other unfortunate mishaps, so keep reading - it pays to understand what's really going on.
 
@@ -37,7 +37,7 @@ To fix that, simply ensure your flush interval is at least as long as the highes
 
 ### Storage Aggregation
 
-The next step is ensuring your data isn't corrupted or discarded when downsampled. Continuing with the example above, take for instance the downsampling of .mean values calculated for all statsd timers: 
+The next step is ensuring your data isn't corrupted or discarded when downsampled. Continuing with the example above, take for instance the downsampling of .mean values calculated for all StatsD timers: 
 
 Graphite should downsample up to 6 samples representing 10-second mean values into a single value signfying the mean for a 1-minute timespan. This is simple: just average all samples to get the new value, and this is exactly the default method applied by Graphite. However, what about the .count metric also sent for timers? Each sample contains the count of occurences per flush interval, so you want these samples summed-up, not averaged! 
 
@@ -45,7 +45,7 @@ You would not even notice any problem till you look at a graph for data older th
 
 Two other metric kinds also deserve a note: 
 
-* Counts which are normalized by statsd to signify a per-second count should not be summed, since their meaning does not change when downsampling. 
+* Counts which are normalized by StatsD to signify a per-second count should not be summed, since their meaning does not change when downsampling. 
 
 * Metrics for minimum/maximum values should not be averaged but rather preserve the lowest/highest point, respectively.
 
@@ -100,6 +100,6 @@ Similar to retentions, the aggregations in effect for any metric are set once th
 
 ### In conclusion
 
-Graphite's handling of your statsd metrics should be verified at least once: is data mysteriously lost at any point? is data downsampled properly? are you defining graphs for counter metrics without knowing what timespan does each y-value actually represent? (admittedly, in some cases you may not even care about the y-values in the graph, as only the trend is of any interest. The coolest graphs seem to always lack y-values...)
+Graphite's handling of your StatsD metrics should be verified at least once: is data mysteriously lost at any point? is data downsampled properly? are you defining graphs for counter metrics without knowing what timespan does each y-value actually represent? (admittedly, in some cases you may not even care about the y-values in the graph, as only the trend is of any interest. The coolest graphs seem to always lack y-values...)
 
 For more information, see: http://graphite.readthedocs.org/en/latest/config-carbon.html

--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -24,12 +24,12 @@ This translates to: for all metrics starting with 'stats' (i.e. all metrics sent
 
 These settings have been a good tradeoff so far between size-of-file (database files are fixed size) and data we care about. Each "stats" database file is about 3.2 megs with these retentions.
 
-Retentions are read from the file in order and the first pattern that matches is used. 
+Retentions are read from the file in order and the first pattern that matches is used.
 Graphite stores each metric in its own database file, and the retentions take effect when a metric file is first created. This means that changing this config file would not affect any files already created. To view or alter the settings on existing files, use whisper-info.py and whisper-resize.py included with the Whisper package.
 
 #### Correlation with StatsD's flush interval:
 
-In the case of the above example, what would happen if you flush from StatsD any faster than every 10 seconds? in that case, multiple values for the same metric may reach Graphite at any given 10-second timespan, and only the last value would take hold and be persisted - so your data would immediately be partially lost. 
+In the case of the above example, what would happen if you flush from StatsD any faster than every 10 seconds? in that case, multiple values for the same metric may reach Graphite at any given 10-second timespan, and only the last value would take hold and be persisted - so your data would immediately be partially lost.
 
 To fix that, simply ensure your flush interval is at least as long as the highest-resolution retention. However, a long interval may cause other unfortunate mishaps, so keep reading - it pays to understand what's really going on.
 
@@ -37,15 +37,15 @@ To fix that, simply ensure your flush interval is at least as long as the highes
 
 ### Storage Aggregation
 
-The next step is ensuring your data isn't corrupted or discarded when downsampled. Continuing with the example above, take for instance the downsampling of .mean values calculated for all StatsD timers: 
+The next step is ensuring your data isn't corrupted or discarded when downsampled. Continuing with the example above, take for instance the downsampling of .mean values calculated for all StatsD timers:
 
-Graphite should downsample up to 6 samples representing 10-second mean values into a single value signfying the mean for a 1-minute timespan. This is simple: just average all samples to get the new value, and this is exactly the default method applied by Graphite. However, what about the .count metric also sent for timers? Each sample contains the count of occurences per flush interval, so you want these samples summed-up, not averaged! 
+Graphite should downsample up to 6 samples representing 10-second mean values into a single value signfying the mean for a 1-minute timespan. This is simple: just average all samples to get the new value, and this is exactly the default method applied by Graphite. However, what about the .count metric also sent for timers? Each sample contains the count of occurences per flush interval, so you want these samples summed-up, not averaged!
 
 You would not even notice any problem till you look at a graph for data older than 6 hours ago, since Graphite would need only the high-res 10-second samples to render the first 6 hours, but would have to switch to lower resolution data for rendering a longer timespan.
 
-Two other metric kinds also deserve a note: 
+Two other metric kinds also deserve a note:
 
-* Counts which are normalized by StatsD to signify a per-second count should not be summed, since their meaning does not change when downsampling. 
+* Counts which are normalized by StatsD to signify a per-second count should not be summed, since their meaning does not change when downsampling.
 
 * Metrics for minimum/maximum values should not be averaged but rather preserve the lowest/highest point, respectively.
 

--- a/docs/graphite_pickle.md
+++ b/docs/graphite_pickle.md
@@ -30,7 +30,7 @@ This ends up looking like:
 The graphite receiver `carbon.protocols.MetricPickleReceiver` coerces
 both the timestamp and measured value into `float`.
 
-The timestamp must be seconds since epoch encoded as a number. 
+The timestamp must be seconds since epoch encoded as a number.
 
 The measured value is encoded as a string. This may change in the
 future.

--- a/docs/graphite_pickle.md
+++ b/docs/graphite_pickle.md
@@ -1,6 +1,6 @@
 # Pickling for Graphite
 
-The graphite statsd backend can optionally be configured to use pickle
+The graphite StatsD backend can optionally be configured to use pickle
 for its over-the-wire protocol.
 
 ```javascript

--- a/docs/metric_types.md
+++ b/docs/metric_types.md
@@ -77,7 +77,7 @@ i.e. class intervals of different sizes.
 
 ## Gauges
 
-StatsD also supports gauges. A gauge will take on the arbitrary value assigned to it, and will maintain it's value until it is next set.
+StatsD also supports gauges. A gauge will take on the arbitrary value assigned to it, and will maintain its value until it is next set.
 
     gaugor:333|g
 

--- a/docs/metric_types.md
+++ b/docs/metric_types.md
@@ -8,7 +8,7 @@ This is a simple counter. Add 1 to the "gorets" bucket.
 At each flush the current count is sent and reset to 0.
 If the count at flush is 0 then you can opt to send no metric at all for
 this counter, by setting `config.deleteCounters` (applies only to graphite
-backend).  Statsd will send both the rate as well as the count at each flush.
+backend).  StatsD will send both the rate as well as the count at each flush.
 
 ## Sampling
 
@@ -31,7 +31,7 @@ generate the following list of stats for each threshold:
     stats.timers.$KEY.upper_$PCT
     stats.timers.$KEY.sum_$PCT
 
-Where `$KEY` is the stats key you specify when sending to statsd, and `$PCT` is
+Where `$KEY` is the stats key you specify when sending to StatsD, and `$PCT` is
 the percentile threshold.
 
 Note that the `mean` metric is the mean value of all timings recorded during
@@ -43,11 +43,11 @@ more detailed explanation of the calculation.
 If the count at flush is 0 then you can opt to send no metric at all for this timer,
 by setting `config.deleteTimers`.
 
-Use the `config.histogram` setting to instruct statsd to maintain histograms
+Use the `config.histogram` setting to instruct StatsD to maintain histograms
 over time.  Specify which metrics to match and a corresponding list of
 ordered non-inclusive upper limits of bins (class intervals).
 (use `inf` to denote infinity; a lower limit of 0 is assumed)
-Each `flushInterval`, statsd will store how many values (absolute frequency)
+Each `flushInterval`, StatsD will store how many values (absolute frequency)
 fall within each bin (class interval), for all matching metrics.
 Examples:
 
@@ -63,7 +63,7 @@ Examples:
         [ { metric: 'foo', bins: [] },
           { metric: '', bins: [ 50, 100, 150, 200, 'inf'] } ]
 
-Statsd also maintains a counter for each timer metric. The 3rd field
+StatsD also maintains a counter for each timer metric. The 3rd field
 specifies the sample rate for this counter (in this example @0.1). The field
 is optional and defaults to 1.
 

--- a/docs/server_implementations.md
+++ b/docs/server_implementations.md
@@ -1,12 +1,12 @@
 # Server Implementations
 
-The following is a list of projects that re-implement statsd, if the the main project isn't for you, perhaps one of these is.
+The following is a list of projects that re-implement StatsD, if the the main project isn't for you, perhaps one of these is.
 
 * [brubeck](https://github.com/github/brubeck) - Server in C
 * [clj-statsd-svr](https://github.com/netmelody/clj-statsd-svr) — Clojure server
 * [gographite](https://github.com/amir/gographite) — Server in Go
 * [gostatsd](https://github.com/atlassian/gostatsd) — Server in Go
-* [netdata](https://github.com/firehol/netdata) - Embedded statsd server in the netdata server, in C, with visualization
+* [netdata](https://github.com/firehol/netdata) - Embedded StatsD server in the netdata server, in C, with visualization
 * [Net::Statsd::Server](https://github.com/cosimo/perl5-net-statsd-server) — Perl server, also available on [CPAN](https://metacpan.org/module/Net::Statsd::Server)
 * [Py-Statsd](https://github.com/sivy/py-statsd) — Server and Client
 * [Ruby-Statsdserver](https://github.com/fetep/ruby-statsdserver) — Ruby server


### PR DESCRIPTION
Mostly, this makes the spelling of "StatsD" consistent. In addition, it fixes a few other typos.