### PR TITLE
Splitting doc links for Elasticsearch 7 backend

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -37,7 +37,9 @@ queues and third-party services.
 * [node-bell](https://github.com/eleme/node-bell)
 * [couchdb-backend](https://github.com/sysadminmike/couch-statsd-backend)
 * [datadog-backend](https://github.com/DataDog/statsd-datadog-backend)
-* [elasticsearch-backend](https://github.com/markkimsal/statsd-elasticsearch-backend)
+* elasticsearch-backend
+  * [Elasticsearch 5 and 6](https://github.com/markkimsal/statsd-elasticsearch-backend)
+  * [Elasticsearch 7](https://github.com/lorenzoaiello/statsd-elasticsearch7-backend)
 * [ganglia-backend](https://github.com/jbuchbinder/statsd-ganglia-backend)
 * [hosted graphite backend](https://github.com/hostedgraphite/statsdplugin)
 * [influxdb backend](https://github.com/bernd/statsd-influxdb-backend)


### PR DESCRIPTION
Elasticsearch 7 introduced major breaking changes by eliminating "Document Types" (deprecated in 6) which required some refactoring of the code to support the new bulk insert API data contracts.

Given that the current `statsd-elasticsearch-backend` hasn't received updates or accepted proposed pull requests to implement these changes, I've forked it and implemented the necessary changes for Elasticsearch 7 into a new package (`statsd-elasticsearch7-backend`).

This pull request simply updates the documentation to reflect this package distinction/separation.