### PR TITLE
don't remove tagging characters when sanitizing metric names

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -14,7 +14,7 @@
  *   graphitePort: Port for the graphite text collector. Defaults to 2003.
  *   graphitePicklePort: Port for the graphite pickle collector. Defaults to 2004.
  *   graphiteProtocol: Either 'text' or 'pickle'. Defaults to 'text'.
- * 
+ *
  * If graphiteHost is not specified, metrics are processed but discarded.
  */
 
@@ -108,7 +108,7 @@ function Metric(key, value, ts) {
   this.value = value;
   this.ts = ts;
 
-  // return a string representation of this metric appropriate 
+  // return a string representation of this metric appropriate
   // for sending to the graphite collector. does not include
   // a trailing newline.
   this.toText = function() {
@@ -167,7 +167,7 @@ var flush_stats = function graphite_flush(ts, metrics) {
     } else {
       return key.replace(/\s+/g, '_')
                 .replace(/\//g, '-')
-                .replace(/[^a-zA-Z_\-0-9\.]/g, '');
+                .replace(/[^a-zA-Z_\-0-9\.;=]/g, '');
     }
   };
 

--- a/stats.js
+++ b/stats.js
@@ -165,7 +165,7 @@ function sanitizeKeyName(key) {
   if (keyNameSanitize) {
     return key.replace(/\s+/g, '_')
               .replace(/\//g, '-')
-              .replace(/[^a-zA-Z_\-0-9\.]/g, '');
+              .replace(/[^a-zA-Z_\-0-9\.;=]/g, '');
   } else {
     return key;
   }


### PR DESCRIPTION
This fixes the issue referenced in #643 where tagged series names have the `;` and `=` characters stripped off by the sanitization code.

With this patch those characters are no longer stripped, allowing the use of tagged series.

There are a couple of issues with this approach which are that there is no handling for scenarios where suffixes are added to the series names, so the utility of supporting tags is limited to gauges without further changes.

The other issue is that anyone who is sending metrics today that include those characters will see their series names change as they will no longer be stripped.