### PR TITLE
Graphite tagged metrics support

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -167,7 +167,7 @@ var flush_stats = function graphite_flush(ts, metrics) {
     } else {
       return key.replace(/\s+/g, '_')
                 .replace(/\//g, '-')
-                .replace(/[^a-zA-Z_\-0-9\.]/g, '');
+                .replace(/[^a-zA-Z_\-0-9\.;=]/g, '');
     }
   };
 

--- a/stats.js
+++ b/stats.js
@@ -165,7 +165,7 @@ function sanitizeKeyName(key) {
   if (keyNameSanitize) {
     return key.replace(/\s+/g, '_')
               .replace(/\//g, '-')
-              .replace(/[^a-zA-Z_\-0-9\.]/g, '');
+              .replace(/[^a-zA-Z_\-0-9\.;=]/g, '');
   } else {
     return key;
   }

--- a/stats.js
+++ b/stats.js
@@ -253,15 +253,17 @@ config.configFile(process.argv[2], function (config) {
           l.log(metrics[midx].toString());
         }
 
-        let bits = metrics[midx].toString().split('#');
-        let tags = null;
-        if (bits.length > 1) {
-          tags = bits[1];
+        let bits = metrics[midx].toString().split('|#');
+        let tags = [];
+        if (bits.length > 1 && bits[1].length > 0) {
+          tags = bits[1].split(',');
         }
         bits = bits[0].split(':');
         let key = bits.shift();
-        if (tags) {
-          key += ';' + tags.replace(',',';').replace(':','=');
+        if (tags.length > 0) {
+          key += ';' + tags.map(function(tag) {
+            return tag.replace(';', '_').replace(':', '=');
+          }).join(';');
         }
         key = sanitizeKeyName(key);
 

--- a/stats.js
+++ b/stats.js
@@ -252,8 +252,18 @@ config.configFile(process.argv[2], function (config) {
         if (config.dumpMessages) {
           l.log(metrics[midx].toString());
         }
-        const bits = metrics[midx].toString().split(':');
-        const key = sanitizeKeyName(bits.shift());
+
+        let bits = metrics[midx].toString().split('#');
+        let tags = null;
+        if (bits.length > 1) {
+          tags = bits[1];
+        }
+        bits = bits[0].split(':');
+        let key = bits.shift();
+        if (tags) {
+          key += ';' + tags.replace(',',';').replace(':','=');
+        }
+        key = sanitizeKeyName(key);
 
         if (keyFlushInterval > 0) {
           if (! keyCounter[key]) {


### PR DESCRIPTION
This PR adds full support for tagged metrics, including sensible handling for suffixes by adding them to the end of the metric name, before any tags.

It also adds support for the "dogstatsd" input format, and if dogstatsd-style tags are specified adds them as graphite tags.

This fixes the deficiencies noted in #696