### PR TITLE
delete state of metrics on ring members change

### DIFF
--- a/exampleProxyConfig.js
+++ b/exampleProxyConfig.js
@@ -15,6 +15,7 @@ Optional Variables:
   host:             address to listen on over UDP [default: 0.0.0.0]
   address_ipv6:     defines if the listen address is an IPv4 or IPv6 address [true or false, default: false]
   checkInterval:    health status check interval [default: 10000]
+  resetStats:       delete state of metrics on ring members change (add or remove) [default: false]
   cacheSize:        size of the cache to store for hashring key lookups [default: 10000]
   forkCount:        number of child processes (cluster module), number or 'auto' for utilize all cpus [default:0]
   server:           the server to load. The server must exist by name in the directory
@@ -37,6 +38,7 @@ port: 8125,
 udp_version:'udp4',
 mgmt_port: 8126,
 forkCount: 0,
+resetStats: false,
 checkInterval: 1000,
 cacheSize: 10000
 }

--- a/lib/mgmt_console.js
+++ b/lib/mgmt_console.js
@@ -46,6 +46,11 @@ exports.delete_stats = function(stats_type, cmdline, stream) {
 function existing_stats(stats_type, bucket){
   matches = [];
 
+  //special case: match a whole of stats
+  if (bucket == "*") {
+    return Object.keys(stats_type).slice()
+  }
+
   //typical case: one-off, fully qualified
   if (bucket in stats_type) {
     matches.push(bucket);

--- a/test/mgmt_console_tests.js
+++ b/test/mgmt_console_tests.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   
   stat_deletes: function(test) {
-    test.expect(6);
+    test.expect(8);
     
     var stream = {
         buffer : '',
@@ -59,6 +59,14 @@ module.exports = {
     
     test.deepEqual(stat_vertical, {'d':1});
     test.equal(stream.buffer, 'deleted: a.b\ndeleted: a.c\nEND\n\n');
+
+    //delete all
+    stat_vertical = {'a.b':1,'a.c':1,'d':1};
+    stream.clear();
+    mgmt.delete_stats(stat_vertical, ['*'], stream);
+
+    test.deepEqual(stat_vertical, {});
+    test.equal(stream.buffer, 'deleted: a.b\ndeleted: a.c\ndeleted: d\nEND\n\n');
     
     test.done();
   },


### PR DESCRIPTION
Sending this PR In order to deal the following #716.
There is a different PR #348 which is not working. After I've looked into that code I notice that  it try to resert state by using `del` functions without any argument. According to documentation `del` functions can delete one metric or folders of metrics, I've added a new delete ability which delete all metrics with `*` sign. 

In addition, I've toggle this feature using proxy configuration file in order to not force this behavior for the user.  
This feature should be a replacement to the existing `deleteIdleStats: true`.