### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -39,7 +39,7 @@ To fix that, simply ensure your flush interval is at least as long as the highes
 
 The next step is ensuring your data isn't corrupted or discarded when downsampled. Continuing with the example above, take for instance the downsampling of .mean values calculated for all StatsD timers:
 
-Graphite should downsample up to 6 samples representing 10-second mean values into a single value signfying the mean for a 1-minute timespan. This is simple: just average all samples to get the new value, and this is exactly the default method applied by Graphite. However, what about the .count metric also sent for timers? Each sample contains the count of occurences per flush interval, so you want these samples summed-up, not averaged!
+Graphite should downsample up to 6 samples representing 10-second mean values into a single value signifying the mean for a 1-minute timespan. This is simple: just average all samples to get the new value, and this is exactly the default method applied by Graphite. However, what about the .count metric also sent for timers? Each sample contains the count of occurrences per flush interval, so you want these samples summed-up, not averaged!
 
 You would not even notice any problem till you look at a graph for data older than 6 hours ago, since Graphite would need only the high-res 10-second samples to render the first 6 hours, but would have to switch to lower resolution data for rendering a longer timespan.
 

--- a/docs/metric_types.md
+++ b/docs/metric_types.md
@@ -99,7 +99,7 @@ without first setting it to zero.
 
 ## Sets
 
-StatsD supports counting unique occurences of events between flushes,
+StatsD supports counting unique occurrences of events between flushes,
 using a Set to store all occuring events.
 
     uniques:765|s

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -32,7 +32,7 @@ Optional Variables:
     address_ipv6:   defines if the address is an IPv4 or IPv6 address [true or false, default: false]
     port:           port to listen for messages on [default: 8125]
     socket:         (only for tcp servers) path to unix domain socket which will be used to receive
-                    metrics [default: undefinded]
+                    metrics [default: undefined]
     socket_mod:     (only for tcp servers) file mode which should be applied to unix domain socket, relevant
                     only if socket option is used [default: undefined]
 

--- a/examples/python_example.py
+++ b/examples/python_example.py
@@ -150,7 +150,7 @@ class StatsdClient(object):
         >>> StatsdClient.send({"example.send":"11|c"}, ("127.0.0.1", 8125))
         """
         # TODO(rbtz@): IPv6 support
-        # TODO(rbtz@): Creating socket on each send is a waste of recources
+        # TODO(rbtz@): Creating socket on each send is a waste of resources
         udp_sock = socket(AF_INET, SOCK_DGRAM)
         # TODO(rbtz@): Add batch support
         for item in _dict.items():

--- a/proxy.js
+++ b/proxy.js
@@ -115,7 +115,7 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
       if (packet_data.indexOf("\n") > -1) {
         var metrics;
         metrics = packet_data.split("\n");
-        // Loop through the metrics and split on : to get mertric name for hashing
+        // Loop through the metrics and split on : to get metric name for hashing
         for (var midx in metrics) {
           current_metric = metrics[midx];
           bits = current_metric.split(':');
@@ -139,10 +139,10 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
     var client = dgram.createSocket(udp_version);
     // Listen for the send message, and process the metric key and msg
     packet.on('send', function(key, msg) {
-      // retreives the destination for this key
+      // retrieves the destination for this key
       var statsd_host = ring.get(key);
 
-      // break the retreived host to pass to the send function
+      // break the retrieved host to pass to the send function
       if (statsd_host === undefined) {
         log('Warning: No backend statsd nodes available!', 'WARNING');
       } else {


### PR DESCRIPTION
There are small typos in:
- docs/graphite.md
- docs/metric_types.md
- exampleConfig.js
- examples/python_example.py
- proxy.js

Fixes:
- Should read `occurrences` rather than `occurences`.
- Should read `undefined` rather than `undefinded`.
- Should read `signifying` rather than `signfying`.
- Should read `retrieves` rather than `retreives`.
- Should read `retrieved` rather than `retreived`.
- Should read `resources` rather than `recources`.
- Should read `metric` rather than `mertric`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md