### PR TITLE
Update Node base for the Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-- '10'
-- '12'
 - '14'
+- '16'
+- '18'
 script: node run_tests.js
 notifications:
   email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.3
+FROM node:18.16.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/test/graphite_pickle_tests.js
+++ b/test/graphite_pickle_tests.js
@@ -95,7 +95,7 @@ var unpickle = function(payload, cb) {
         fs.close(unpickle_info.fd, function(err) {
           if (err) throw err;
 
-          var cmd = 'python ' + unpickle_info.path + ' ' + payload_info.path;
+          var cmd = 'python3 ' + unpickle_info.path + ' ' + payload_info.path;
           var python = cp.exec(cmd, function(err, stdout, stderr) {
             if (err) throw err;
             var metrics = JSON.parse(stdout);


### PR DESCRIPTION
Hi

I opened an issue here: https://github.com/statsd/statsd/issues/737. The official docker image is running a deprecated Debian version and deprecated Node version. 

I have run the tests locally under Node 18 and Node 16 and they all pass. 

Please let me know if there are further changes I should make.