### PR TITLE
Create multi-arch images

### DIFF
--- a/.github/workflows/package-and-publish-image.yml
+++ b/.github/workflows/package-and-publish-image.yml
@@ -57,6 +57,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          platforms: linux/amd64,linux/s390x
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Echo image digest


### PR DESCRIPTION
Below change will enable building and releasing multi-arch statsd images for amd64 and s390x.
More platforms can be enabled by appending those to "platforms" parameter below.

Is existing docker image not public on ghcr? It gives unauthorized error if pulled.