### PR TITLE
Bump node version to support arm based os

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16.0
+FROM node:20.11.0-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Node version selected on the basis of vulnerabilities analysis
https://hub.docker.com/layers/library/node/20.11.0-alpine/images/sha256-6dbf56a08bcade5ee1e2196cce346182ab52bad9dcf308f4bc7b36eefb318662?context=explore