### PR TITLE
Node alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16.0
+FROM node:18.16.0-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 # RUN apk add --no-cache --update g++ gcc libgcc libstdc++ linux-headers make python
 
 # Setup node envs
-ARG NODE_ENV
+ARG NODE_ENV="production"
 ENV NODE_ENV $NODE_ENV
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ StatsD supports docker in three ways:
 * The official container image on [DockerHub](https://hub.docker.com/r/statsd/statsd)
 * Building the image from the bundled [Dockerfile](./Dockerfile)
 
+To configure the statsd container, create a `config.js` file (you can refer to `exampleConfig.js` for guidance),
+and then add the volume to the container as follows:
+```
+docker run statsd/statsd -v /path/to/config.js:/usr/src/app/config.js
+```
+
 ### Manual installation
  * Install Node.js (All [`Current` and `LTS` Node.js versions](https://nodejs.org/en/about/releases/) are supported.)
  * Clone the project


### PR DESCRIPTION
Docker image: use alpine as base image

Changes base image from `node:18.16.0` to `node:18.16.0-alpine`.
This change dramatically affects docker image size: down from 1.21gb to 178mb.

Adds "production" as default for build arg `NODE_ENV`.

Also adds a "how to configure docker image" section to `README.MD` (#727).