### PR TITLE
Do not watch config file if 'automaticConfigReload' was disabled

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,7 +9,7 @@ let Configurator = function (file) {
   let config = {};
   let oldConfig = {};
 
-  this.updateConfig = function () {
+  this.updateConfig = function (initial = false) {
     util.log('[' + process.pid + '] reading config file: ' + file);
 
     fs.readFile(file, function (err, data) {
@@ -18,16 +18,18 @@ let Configurator = function (file) {
 
       self.config = eval('config = ' + data);
       self.emit('configChanged', self.config);
+
+      if (initial && self.config.automaticConfigReload == true) {
+        fs.watch(file, function (event, filename) {
+            if (event == 'change') {
+              self.updateConfig();
+            }
+        });
+      }
     });
   };
 
-  this.updateConfig();
-
-  fs.watch(file, function (event, filename) {
-    if (event == 'change' && self.config.automaticConfigReload != false) {
-      self.updateConfig();
-    }
-  });
+  this.updateConfig(true);
 };
 
 util.inherits(Configurator, require('events').EventEmitter);


### PR DESCRIPTION
I might be wrong, but it doesn’t make sense to start watching the config file if automaticConfigReload is turned off from the start

It seems this could cause: `EMFILE: too many open files, watch 'config.js'`