### PR TITLE
Fix building Debian package on 12 Bookworm

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Elliot Blackburn <elliot@lybrary.io>
 Standards-Version: 3.9.3
-Build-Depends: debhelper (>= 8.0.0), dh-systemd (>= 1.5)
+Build-Depends: debhelper (>= 12)
 
 Package: statsd
 Architecture: all


### PR DESCRIPTION
While building statsd on Debian I got the following error:

```
dpkg-checkbuilddeps: error: Unmet build dependencies: dh-systemd (>= 1.5)
```

dh-systemd package seems to be merged into debhelper and no longer exists.

https://wiki.debian.org/Teams/pkg-systemd/Packaging