### PR TITLE
Enable arm64 build

### DIFF
--- a/.github/workflows/package-and-publish-image.yml
+++ b/.github/workflows/package-and-publish-image.yml
@@ -57,7 +57,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          platforms: linux/amd64,linux/s390x
+          platforms: linux/amd64,linux/s390x,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Echo image digest


### PR DESCRIPTION
Hey!

It would be nice to add arm64 architecture. This architecture is often necessary for our tasks, could we add this in the build?

I checked the arm64 build on my fork, everything is builded correctly.

@elliotblackburn